### PR TITLE
Removed editDelimit from README.md due to non existent

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var WidgetMath = widgets.createType({
                 }
             };
         }),
-        widgets.mixins.editDelimit('$$', '$$')
+        widgets.mixins.editParagraph()
     ],
 
     createElement: function(widget) {


### PR DESCRIPTION
`editDelimit` was removed in a474d19a8baccc28ec7d5c9b7e40440673709018 and is cause to update the README to reflect that. I've updated the README file to use `editParagraph` instead.